### PR TITLE
bug fix of _categoryList()

### DIFF
--- a/nucleus/xmlrpc/api_metaweblog.inc.php
+++ b/nucleus/xmlrpc/api_metaweblog.inc.php
@@ -413,7 +413,7 @@ if (!isset($member))
 
 		$b = new BLOG($blogid);
 
-		$categorystruct = array();
+		$structarray = array();
 
 		$query =  "SELECT cname, cdesc, catid"
 				. ' FROM '.sql_table('category')
@@ -422,19 +422,18 @@ if (!isset($member))
 		$r = sql_query($query);
 
 		while ($obj = sql_fetch_object($r)) {
-
-			$categorystruct[$obj->cname] = new xmlrpcval(
+			array_push($structarray, new xmlrpcval(
 				array(
+					"title" => new xmlrpcval($obj->cname,"string"),
+					"categoryId" => new xmlrpcval($obj->catid,"string"),
 					"description" => new xmlrpcval($obj->cdesc,"string"),
 					"htmlUrl" => new xmlrpcval($b->getURL() . "?catid=" . $obj->catid ,"string"),
 					"rssUrl" => new xmlrpcval("","string")
 				)
-			,'struct');
+			,'struct'));
 		}
 
-
-		return new xmlrpcresp(new xmlrpcval( $categorystruct , "struct"));
-
+		return new xmlrpcresp(new xmlrpcval( $structarray , "array"));
 	}
 
 


### PR DESCRIPTION
Bug fix of _categoryList().

This function is called from f_metaWeblog_getCategories().
Response data of metaWeblog.getCategories must be an array of category structures. Not a structure of category structures(also current code creates a corrupt response data).

XML-RPC clients get category names from 'title' element of the structs.
According to Microsoft, they think both 'title' and 'description' have category name for Windows Live Spaces MetaWeblog API, but I think 'description' should have description of the category since the element is named as 'description'. 😃

Tested by Open Live Writer 0.6.2.0 and the code is okay.