### PR TITLE
Improve classic skin color palette for better readability

### DIFF
--- a/skins/classic/left.css
+++ b/skins/classic/left.css
@@ -158,9 +158,9 @@ a:hover, a:active
 	line-height: 80px;
 
     /* #FCC800 #F3A68C #CAB8D9 #C0DCC0  */
-    background: #314A7E linear-gradient(top center, #F7FAFF 0%, #314A7E 100%);
-    background: #314A7E -moz-linear-gradient(top center, #F7FAFF 0%, #314A7E 100%);
-    background: #314A7E -webkit-gradient(linear, center top, center bottom, from(#F7FAFF), to(#314A7E));
+    background: #314A7E linear-gradient(top center, #314A7E 0%, #F7FAFF 100%);
+    background: #314A7E -moz-linear-gradient(top center, #314A7E 0%, #F7FAFF 100%);
+    background: #314A7E -webkit-gradient(linear, center top, center bottom, from(#314A7E), to(#F7FAFF));
 
 	/* small header image specific lines */
 /*	height: 168px;

--- a/skins/classic/left.css
+++ b/skins/classic/left.css
@@ -16,7 +16,7 @@
         /*display: block;*/
     }
     #menu_region {
-        background-color: rgba(255, 251, 182, 0.2);
+        background-color: rgba(49, 74, 126, 0.08);
         position: fixed;
         width: 100%;
         height: 100%;
@@ -56,13 +56,13 @@
 -------------------------------------------------*/
 body
 {
-    background: #FFFFE1;
-	/*background: #505050 url(images/bg.gif);*/
-	color: #494949;
-	font-family: "Lucida Grande", "Lucida Sans Unicode", "Trebuchet MS", Trebuchet, Arial, sans-serif;
-	font-size: medium;
-	padding: 15px 0;
-	margin: 0;
+    background: #F4F6FA;
+        /*background: #505050 url(images/bg.gif);*/
+        color: #2D3748;
+        font-family: "Lucida Grande", "Lucida Sans Unicode", "Trebuchet MS", Trebuchet, Arial, sans-serif;
+        font-size: medium;
+        padding: 15px 0;
+        margin: 0;
 }
 img
 {
@@ -95,28 +95,28 @@ li
 /* Links */
 a:link, a:visited
 {
-	color: #635D45;
-	text-decoration: none;
+        color: #2E5D9F;
+        text-decoration: none;
 }
 a:hover, a:active
 {
-	color: black;
+        color: #1F3F6B;
 }
 #header a:link, #header a:visited
 {
-	color: #474747;
+        color: #F5F7FB;
 }
 #header a:hover, #header a:active
 {
-	color: #737373;
+        color: #DCE6F5;
 }
 #copyrights a:link, #copyrights a:visited
 {
-	color: #474747;
+        color: #E8ECF5;
 }
 #copyrights a:hover, #copyrights a:active
 {
-	color: #737373;
+        color: #DCE6F5;
 }
 
 /* Basic classes */
@@ -144,12 +144,12 @@ a:hover, a:active
 	height: 100px;
 	/*height: 168px;*/
 	/* large header image is defined below */
-	/* background: white url(images/header.jpg) no-repeat; */
-	background: white;
-	border-width: 2px 2px 0;
-	border-style: solid;
-	border-color: #E0E0E0;
-	margin: auto;
+        /* background: white url(images/header.jpg) no-repeat; */
+        background: white;
+        border-width: 2px 2px 0;
+        border-style: solid;
+        border-color: #D7DEE8;
+        margin: auto;
 }
 #header h1
 {
@@ -158,9 +158,9 @@ a:hover, a:active
 	line-height: 80px;
 
     /* #FCC800 #F3A68C #CAB8D9 #C0DCC0  */
-    background: #CAB8D9 linear-gradient(top center, #fff 0%, #CAB8D9 100%);
-    background: #CAB8D9 -moz-linear-gradient(top center, #fff 0%, #CAB8D9 100%);
-    background: #CAB8D9 -webkit-gradient(linear, center top, center bottom, from(#fff), to(#CAB8D9));
+    background: #314A7E linear-gradient(top center, #F7FAFF 0%, #314A7E 100%);
+    background: #314A7E -moz-linear-gradient(top center, #F7FAFF 0%, #314A7E 100%);
+    background: #314A7E -webkit-gradient(linear, center top, center bottom, from(#F7FAFF), to(#314A7E));
 
 	/* small header image specific lines */
 /*	height: 168px;
@@ -169,9 +169,10 @@ a:hover, a:active
 	line-height: 160px;
     background: white url(images/header_sm.jpg) repeat-x 0 6px;*/
 
-	/* end small header image specific lines */
-	font-size: 38px;
-	text-align: center;
+        /* end small header image specific lines */
+        font-size: 38px;
+        text-align: center;
+        color: #F5F7FB;
 }
 
 /*-------------------------------------------------
@@ -179,11 +180,11 @@ a:hover, a:active
 -------------------------------------------------*/
 #mainwrapper
 {
-	background: white;
-	border-width: 0 2px;
-	border-style: solid;
-	border-color: #E0E0E0;
-	margin: auto;
+        background: white;
+        border-width: 0 2px;
+        border-style: solid;
+        border-color: #D7DEE8;
+        margin: auto;
 }
 #wrapper
 {
@@ -351,28 +352,28 @@ a:hover, a:active
 
 .sidebardl dt
 {
-	background: #3399FF ;/* url(images/sidetitlebg.gif); */
-	color: #FFFFFF;
-	/*background: #E5E5E5 url(images/sidetitlebg.gif);*/
-	/*color: #3A3523;*/
-	font-size: 0.9em;
+        background: #2E5D9F ;/* url(images/sidetitlebg.gif); */
+        color: #FFFFFF;
+        /*background: #E5E5E5 url(images/sidetitlebg.gif);*/
+        /*color: #3A3523;*/
+        font-size: 0.9em;
 	font-weight: bold;
 	font-family: "Georgia", "Lucida Grande", "Lucida Sans Unicode", Arial, "Trebuchet MS", sans-serif;
 	padding: 4px 10px;
 }
 .sidebardl dd
 {
-    background: #D7E4F2;
-	/*background: #EEEEEE;*/
-	padding: 2px 10px;
-	margin: 1px 0 0 0;
+    background: #EEF2FA;
+        /*background: #EEEEEE;*/
+        padding: 2px 10px;
+        margin: 1px 0 0 0;
 }
 .sidebardl dd:hover
 {
-    background: #B9D1EA;
-	/*background: #E7E7E7;*/
-	padding: 2px 10px;
-	margin: 1px 0 0 0;
+    background: #E1E8F5;
+        /*background: #E7E7E7;*/
+        padding: 2px 10px;
+        margin: 1px 0 0 0;
 }
 .sidebardl dd a:link, .sidebardl dd a:visited
 {
@@ -385,14 +386,15 @@ a:hover, a:active
 -------------------------------------------------*/
 #footer
 {
-	/*background: #FCD21B;*/
-	background: #CAB8D9;
-	text-align: center;
-	padding: 10px 0 10px 0;
-	border-width: 0px 2px 2px 2px;
-	border-style: solid;
-	border-color: #E0E0E0;
-	margin: 0 auto;
+        /*background: #FCD21B;*/
+        background: #314A7E;
+        text-align: center;
+        padding: 10px 0 10px 0;
+        border-width: 0px 2px 2px 2px;
+        border-style: solid;
+        border-color: #D7DEE8;
+        margin: 0 auto;
+        color: #E8ECF5;
 }
 
 #copyrights

--- a/skins/classic/right.css
+++ b/skins/classic/right.css
@@ -18,7 +18,7 @@
         z-index: 110;
     }
     #menu_region {
-        background-color: rgba(255, 251, 182, 0.2);
+        background-color: rgba(49, 74, 126, 0.08);
         position: fixed;
         width: 100%;
         height: 100%;
@@ -58,12 +58,12 @@
 -------------------------------------------------*/
 body
 {
-    background: #FFFFE1;
-	/*background: #505050 url(images/bg.gif);*/
-    color: #494949;
-	font-family: "Lucida Grande", "Lucida Sans Unicode", "Trebuchet MS", Trebuchet, Arial, sans-serif;
-	font-size: medium;
-	padding: 15px 0;
+    background: #F4F6FA;
+        /*background: #505050 url(images/bg.gif);*/
+    color: #2D3748;
+        font-family: "Lucida Grande", "Lucida Sans Unicode", "Trebuchet MS", Trebuchet, Arial, sans-serif;
+        font-size: medium;
+        padding: 15px 0;
 	margin: 0;
 }
 img
@@ -97,28 +97,28 @@ li
 /* Links */
 a:link, a:visited
 {
-	color: #635D45;
-	text-decoration: none;
+        color: #2E5D9F;
+        text-decoration: none;
 }
 a:hover, a:active
 {
-	color: black;
+        color: #1F3F6B;
 }
 #header a:link, #header a:visited
 {
-	color: #474747;
+        color: #F5F7FB;
 }
 #header a:hover, #header a:active
 {
-	color: #737373;
+        color: #DCE6F5;
 }
 #copyrights a:link, #copyrights a:visited
 {
-	color: #474747;
+        color: #E8ECF5;
 }
 #copyrights a:hover, #copyrights a:active
 {
-	color: #737373;
+        color: #DCE6F5;
 }
 
 /* Basic classes */
@@ -145,13 +145,13 @@ a:hover, a:active
 	position: relative;
 	height: 100px;
 	/*height: 168px;*/
-	/* large header image is defined below */
-	/* background: white url(images/header.jpg) no-repeat; */
-	background: white;
-	border-width: 2px 2px 0;
-	border-style: solid;
-	border-color: #E0E0E0;
-	margin: auto;
+        /* large header image is defined below */
+        /* background: white url(images/header.jpg) no-repeat; */
+        background: white;
+        border-width: 2px 2px 0;
+        border-style: solid;
+        border-color: #D7DEE8;
+        margin: auto;
 }
 #header h1
 {
@@ -160,9 +160,9 @@ a:hover, a:active
 	line-height: 80px;
 
     /* #FCC800 #F3A68C #CAB8D9 #C0DCC0  */
-    background: #CAB8D9 linear-gradient(top center, #fff 0%, #CAB8D9 100%);
-    background: #CAB8D9 -moz-linear-gradient(top center, #fff 0%, #CAB8D9 100%);
-    background: #CAB8D9 -webkit-gradient(linear, center top, center bottom, from(#fff), to(#CAB8D9));
+    background: #314A7E linear-gradient(top center, #F7FAFF 0%, #314A7E 100%);
+    background: #314A7E -moz-linear-gradient(top center, #F7FAFF 0%, #314A7E 100%);
+    background: #314A7E -webkit-gradient(linear, center top, center bottom, from(#F7FAFF), to(#314A7E));
 
 	/* small header image specific lines */
 /*	height: 168px;
@@ -171,9 +171,10 @@ a:hover, a:active
 	line-height: 160px;
     background: white url(images/header_sm.jpg) repeat-x 0 6px;*/
 
-	/* end small header image specific lines */
-	font-size: 38px;
-	text-align: center;
+        /* end small header image specific lines */
+        font-size: 38px;
+        text-align: center;
+        color: #F5F7FB;
 }
 
 /*-------------------------------------------------
@@ -181,11 +182,11 @@ a:hover, a:active
 -------------------------------------------------*/
 #mainwrapper
 {
-	background: white;
-	border-width: 0 2px;
-	border-style: solid;
-	border-color: #E0E0E0;
-	margin: auto;
+        background: white;
+        border-width: 0 2px;
+        border-style: solid;
+        border-color: #D7DEE8;
+        margin: auto;
 }
 #wrapper
 {
@@ -340,8 +341,8 @@ a:hover, a:active
 }
 .sidebar
 {
-	color: #21262A;
-	margin: 0 6px 4px 0;
+        color: #21262A;
+        margin: 0 6px 4px 0;
 }
 
 /* Menu lists */
@@ -353,28 +354,28 @@ a:hover, a:active
 
 .sidebardl dt
 {
-	background: #3399FF ;/* url(images/sidetitlebg.gif); */
-	color: #FFFFFF;
-	/*background: #E5E5E5 url(images/sidetitlebg.gif);*/
-	/*color: #3A3523;*/
-	font-size: 0.9em;
-	font-weight: bold;
-	font-family: "Georgia", "Lucida Grande", "Lucida Sans Unicode", Arial, "Trebuchet MS", sans-serif;
-	padding: 4px 10px;
+        background: #2E5D9F ;/* url(images/sidetitlebg.gif); */
+        color: #FFFFFF;
+        /*background: #E5E5E5 url(images/sidetitlebg.gif);*/
+        /*color: #3A3523;*/
+        font-size: 0.9em;
+        font-weight: bold;
+        font-family: "Georgia", "Lucida Grande", "Lucida Sans Unicode", Arial, "Trebuchet MS", sans-serif;
+        padding: 4px 10px;
 }
 .sidebardl dd
 {
-    background: #D7E4F2;
-	/*background: #EEEEEE;*/
-	padding: 2px 10px;
-	margin: 1px 0 0 0;
+    background: #EEF2FA;
+        /*background: #EEEEEE;*/
+        padding: 2px 10px;
+        margin: 1px 0 0 0;
 }
 .sidebardl dd:hover
 {
-    background: #B9D1EA;
-	/*background: #E7E7E7;*/
-	padding: 2px 10px;
-	margin: 1px 0 0 0;
+    background: #E1E8F5;
+        /*background: #E7E7E7;*/
+        padding: 2px 10px;
+        margin: 1px 0 0 0;
 }
 .sidebardl dd a:link, .sidebardl dd a:visited
 {
@@ -387,14 +388,15 @@ a:hover, a:active
 -------------------------------------------------*/
 #footer
 {
-	/*background: #FCD21B;*/
-	background: #CAB8D9;
-	text-align: center;
-	padding: 10px 0 10px 0;
-	border-width: 0px 2px 2px 2px;
-	border-style: solid;
-	border-color: #E0E0E0;
-	margin: 0 auto;
+        /*background: #FCD21B;*/
+        background: #314A7E;
+        text-align: center;
+        padding: 10px 0 10px 0;
+        border-width: 0px 2px 2px 2px;
+        border-style: solid;
+        border-color: #D7DEE8;
+        margin: 0 auto;
+        color: #E8ECF5;
 }
 
 #copyrights

--- a/skins/classic/right.css
+++ b/skins/classic/right.css
@@ -160,9 +160,9 @@ a:hover, a:active
 	line-height: 80px;
 
     /* #FCC800 #F3A68C #CAB8D9 #C0DCC0  */
-    background: #314A7E linear-gradient(top center, #F7FAFF 0%, #314A7E 100%);
-    background: #314A7E -moz-linear-gradient(top center, #F7FAFF 0%, #314A7E 100%);
-    background: #314A7E -webkit-gradient(linear, center top, center bottom, from(#F7FAFF), to(#314A7E));
+    background: #314A7E linear-gradient(top center, #314A7E 0%, #F7FAFF 100%);
+    background: #314A7E -moz-linear-gradient(top center, #314A7E 0%, #F7FAFF 100%);
+    background: #314A7E -webkit-gradient(linear, center top, center bottom, from(#314A7E), to(#F7FAFF));
 
 	/* small header image specific lines */
 /*	height: 168px;


### PR DESCRIPTION
## Summary
- refresh the classic skin background, text, and border colors with a softer neutral palette
- update header/footer gradient, sidebar blocks, and overlay tint to use consistent blue tones
- align link and footer text colors for improved contrast on the new scheme

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934357ab158832d904dbb5a84cda280)