### PR TITLE
Doctrine DBALのPHP8属性を削除してPHP7.4互換に

### DIFF
--- a/nucleus/libs/vendor/doctrine/dbal/src/Connection.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Connection.php
@@ -33,7 +33,6 @@ use Doctrine\DBAL\SQL\Parser;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
 use LogicException;
-use SensitiveParameter;
 use Throwable;
 use Traversable;
 
@@ -185,7 +184,6 @@ class Connection
      * @throws Exception
      */
     public function __construct(
-        #[SensitiveParameter]
         array $params,
         Driver $driver,
         ?Configuration $config = null,

--- a/nucleus/libs/vendor/doctrine/dbal/src/Connections/PrimaryReadReplicaConnection.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Connections/PrimaryReadReplicaConnection.php
@@ -15,7 +15,6 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Statement;
 use Doctrine\Deprecations\Deprecation;
 use InvalidArgumentException;
-use SensitiveParameter;
 
 use function array_rand;
 use function count;
@@ -266,7 +265,6 @@ class PrimaryReadReplicaConnection extends Connection
      */
     protected function chooseConnectionConfiguration(
         $connectionName,
-        #[SensitiveParameter]
         $params
     ) {
         if ($connectionName === 'primary') {

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver.php
@@ -7,7 +7,6 @@ use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
-use SensitiveParameter;
 
 /**
  * Driver interface.
@@ -28,7 +27,6 @@ interface Driver
      * @throws Exception
      */
     public function connect(
-        #[SensitiveParameter]
         array $params
     );
 

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver/AbstractSQLiteDriver/Middleware/EnableForeignKeys.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver/AbstractSQLiteDriver/Middleware/EnableForeignKeys.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
-use SensitiveParameter;
 
 class EnableForeignKeys implements Middleware
 {
@@ -17,7 +16,6 @@ class EnableForeignKeys implements Middleware
              * {@inheritDoc}
              */
             public function connect(
-                #[SensitiveParameter]
                 array $params
             ): Connection {
                 $connection = parent::connect($params);

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver/IBMDB2/DataSourceName.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver/IBMDB2/DataSourceName.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Driver\IBMDB2;
 
-use SensitiveParameter;
 
 use function implode;
 use function sprintf;
@@ -18,7 +17,6 @@ final class DataSourceName
     private string $string;
 
     private function __construct(
-        #[SensitiveParameter]
         string $string
     ) {
         $this->string = $string;
@@ -35,7 +33,6 @@ final class DataSourceName
      * @param array<string,mixed> $params
      */
     public static function fromArray(
-        #[SensitiveParameter]
         array $params
     ): self {
         $chunks = [];
@@ -53,7 +50,6 @@ final class DataSourceName
      * @param array<string,mixed> $params
      */
     public static function fromConnectionParameters(
-        #[SensitiveParameter]
         array $params
     ): self {
         if (isset($params['dbname']) && strpos($params['dbname'], '=') !== false) {

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver/IBMDB2/Driver.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver/IBMDB2/Driver.php
@@ -4,7 +4,6 @@ namespace Doctrine\DBAL\Driver\IBMDB2;
 
 use Doctrine\DBAL\Driver\AbstractDB2Driver;
 use Doctrine\DBAL\Driver\IBMDB2\Exception\ConnectionFailed;
-use SensitiveParameter;
 
 use function db2_connect;
 use function db2_pconnect;
@@ -17,7 +16,6 @@ final class Driver extends AbstractDB2Driver
      * @return Connection
      */
     public function connect(
-        #[SensitiveParameter]
         array $params
     ) {
         $dataSourceName = DataSourceName::fromConnectionParameters($params)->toString();

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver/Middleware/AbstractDriverMiddleware.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver/Middleware/AbstractDriverMiddleware.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Driver\API\ExceptionConverter;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
 use Doctrine\Deprecations\Deprecation;
-use SensitiveParameter;
 
 abstract class AbstractDriverMiddleware implements VersionAwarePlatformDriver
 {
@@ -23,7 +22,6 @@ abstract class AbstractDriverMiddleware implements VersionAwarePlatformDriver
      * {@inheritDoc}
      */
     public function connect(
-        #[SensitiveParameter]
         array $params
     ) {
         return $this->wrappedDriver->connect($params);

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver/Mysqli/Driver.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver/Mysqli/Driver.php
@@ -11,7 +11,6 @@ use Doctrine\DBAL\Driver\Mysqli\Initializer\Secure;
 use Generator;
 use mysqli;
 use mysqli_sql_exception;
-use SensitiveParameter;
 
 final class Driver extends AbstractMySQLDriver
 {
@@ -21,7 +20,6 @@ final class Driver extends AbstractMySQLDriver
      * @return Connection
      */
     public function connect(
-        #[SensitiveParameter]
         array $params
     ) {
         if (! empty($params['persistent'])) {
@@ -71,7 +69,6 @@ final class Driver extends AbstractMySQLDriver
      * @return Generator<int, Initializer>
      */
     private function compilePreInitializers(
-        #[SensitiveParameter]
         array $params
     ): Generator {
         unset($params['driverOptions'][Connection::OPTION_FLAGS]);
@@ -105,7 +102,6 @@ final class Driver extends AbstractMySQLDriver
      * @return Generator<int, Initializer>
      */
     private function compilePostInitializers(
-        #[SensitiveParameter]
         array $params
     ): Generator {
         if (! isset($params['charset'])) {

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver/Mysqli/Initializer/Secure.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver/Mysqli/Initializer/Secure.php
@@ -6,7 +6,6 @@ namespace Doctrine\DBAL\Driver\Mysqli\Initializer;
 
 use Doctrine\DBAL\Driver\Mysqli\Initializer;
 use mysqli;
-use SensitiveParameter;
 
 final class Secure implements Initializer
 {
@@ -17,7 +16,6 @@ final class Secure implements Initializer
     private string $cipher;
 
     public function __construct(
-        #[SensitiveParameter]
         string $key,
         string $cert,
         string $ca,

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver/OCI8/Driver.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver/OCI8/Driver.php
@@ -5,7 +5,6 @@ namespace Doctrine\DBAL\Driver\OCI8;
 use Doctrine\DBAL\Driver\AbstractOracleDriver;
 use Doctrine\DBAL\Driver\OCI8\Exception\ConnectionFailed;
 use Doctrine\DBAL\Driver\OCI8\Exception\InvalidConfiguration;
-use SensitiveParameter;
 
 use function oci_connect;
 use function oci_new_connect;
@@ -24,7 +23,6 @@ final class Driver extends AbstractOracleDriver
      * @return Connection
      */
     public function connect(
-        #[SensitiveParameter]
         array $params
     ) {
         $username    = $params['user'] ?? '';

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver/OCI8/Middleware/InitializeSession.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver/OCI8/Middleware/InitializeSession.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
-use SensitiveParameter;
 
 class InitializeSession implements Middleware
 {
@@ -17,7 +16,6 @@ class InitializeSession implements Middleware
              * {@inheritDoc}
              */
             public function connect(
-                #[SensitiveParameter]
                 array $params
             ): Connection {
                 $connection = parent::connect($params);

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver/PDO/MySQL/Driver.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver/PDO/MySQL/Driver.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Driver\PDO\Exception;
 use Doctrine\DBAL\Driver\PDO\PDOConnect;
 use PDO;
 use PDOException;
-use SensitiveParameter;
 
 final class Driver extends AbstractMySQLDriver
 {
@@ -20,7 +19,6 @@ final class Driver extends AbstractMySQLDriver
      * @return Connection
      */
     public function connect(
-        #[SensitiveParameter]
         array $params
     ) {
         $driverOptions = $params['driverOptions'] ?? [];

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver/PDO/OCI/Driver.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver/PDO/OCI/Driver.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Driver\PDO\Exception;
 use Doctrine\DBAL\Driver\PDO\PDOConnect;
 use PDO;
 use PDOException;
-use SensitiveParameter;
 
 final class Driver extends AbstractOracleDriver
 {
@@ -20,7 +19,6 @@ final class Driver extends AbstractOracleDriver
      * @return Connection
      */
     public function connect(
-        #[SensitiveParameter]
         array $params
     ) {
         $driverOptions = $params['driverOptions'] ?? [];

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver/PDO/PDOConnect.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver/PDO/PDOConnect.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\DBAL\Driver\PDO;
 
 use PDO;
-use SensitiveParameter;
 
 use const PHP_VERSION_ID;
 
@@ -14,10 +13,8 @@ trait PDOConnect
 {
     /** @param array<int, mixed> $options */
     private function doConnect(
-        #[SensitiveParameter]
         string $dsn,
         string $username,
-        #[SensitiveParameter]
         string $password,
         array $options
     ): PDO {

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver/PDO/PgSQL/Driver.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver/PDO/PgSQL/Driver.php
@@ -10,7 +10,6 @@ use Doctrine\Deprecations\Deprecation;
 use PDO;
 use Pdo\Pgsql;
 use PDOException;
-use SensitiveParameter;
 
 use const PHP_VERSION_ID;
 
@@ -24,7 +23,6 @@ final class Driver extends AbstractPostgreSQLDriver
      * @return Connection
      */
     public function connect(
-        #[SensitiveParameter]
         array $params
     ) {
         $driverOptions = $params['driverOptions'] ?? [];

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver/PDO/SQLSrv/Driver.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver/PDO/SQLSrv/Driver.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
 use Doctrine\DBAL\Driver\PDO\Exception as PDOException;
 use Doctrine\DBAL\Driver\PDO\PDOConnect;
 use PDO;
-use SensitiveParameter;
 
 use function is_int;
 use function sprintf;
@@ -24,7 +23,6 @@ final class Driver extends AbstractSQLServerDriver
      * @return Connection
      */
     public function connect(
-        #[SensitiveParameter]
         array $params
     ) {
         $driverOptions = $dsnOptions = [];

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver/PDO/SQLite/Driver.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver/PDO/SQLite/Driver.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Driver\PDO\PDOConnect;
 use Doctrine\Deprecations\Deprecation;
 use Pdo\Sqlite;
 use PDOException;
-use SensitiveParameter;
 
 use function array_intersect_key;
 
@@ -24,7 +23,6 @@ final class Driver extends AbstractSQLiteDriver
      * @return Connection
      */
     public function connect(
-        #[SensitiveParameter]
         array $params
     ) {
         $driverOptions        = $params['driverOptions'] ?? [];

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver/PgSQL/Driver.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver/PgSQL/Driver.php
@@ -4,7 +4,6 @@ namespace Doctrine\DBAL\Driver\PgSQL;
 
 use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
 use ErrorException;
-use SensitiveParameter;
 
 use function addslashes;
 use function array_filter;
@@ -26,7 +25,6 @@ final class Driver extends AbstractPostgreSQLDriver
 {
     /** {@inheritDoc} */
     public function connect(
-        #[SensitiveParameter]
         array $params
     ): Connection {
         set_error_handler(
@@ -62,7 +60,6 @@ final class Driver extends AbstractPostgreSQLDriver
      * @param array<string, mixed> $params
      */
     private function constructConnectionString(
-        #[SensitiveParameter]
         array $params
     ): string {
         // pg_connect used by Doctrine DBAL does not support [...] notation,

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver/SQLSrv/Driver.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver/SQLSrv/Driver.php
@@ -5,7 +5,6 @@ namespace Doctrine\DBAL\Driver\SQLSrv;
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
 use Doctrine\DBAL\Driver\AbstractSQLServerDriver\Exception\PortWithoutHost;
 use Doctrine\DBAL\Driver\SQLSrv\Exception\Error;
-use SensitiveParameter;
 
 use function sqlsrv_configure;
 use function sqlsrv_connect;
@@ -21,7 +20,6 @@ final class Driver extends AbstractSQLServerDriver
      * @return Connection
      */
     public function connect(
-        #[SensitiveParameter]
         array $params
     ) {
         $serverName = '';

--- a/nucleus/libs/vendor/doctrine/dbal/src/Driver/SQLite3/Driver.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Driver/SQLite3/Driver.php
@@ -4,7 +4,6 @@ namespace Doctrine\DBAL\Driver\SQLite3;
 
 use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
 use Doctrine\DBAL\Driver\API\SQLite\UserDefinedFunctions;
-use SensitiveParameter;
 use SQLite3;
 
 final class Driver extends AbstractSQLiteDriver
@@ -13,7 +12,6 @@ final class Driver extends AbstractSQLiteDriver
      * {@inheritDoc}
      */
     public function connect(
-        #[SensitiveParameter]
         array $params
     ): Connection {
         $isMemory = (bool) ($params['memory'] ?? false);

--- a/nucleus/libs/vendor/doctrine/dbal/src/DriverManager.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/DriverManager.php
@@ -13,7 +13,6 @@ use Doctrine\DBAL\Driver\SQLSrv;
 use Doctrine\DBAL\Exception\MalformedDsnException;
 use Doctrine\DBAL\Tools\DsnParser;
 use Doctrine\Deprecations\Deprecation;
-use SensitiveParameter;
 
 use function array_keys;
 use function array_merge;
@@ -162,7 +161,6 @@ final class DriverManager
      * @template T of Connection
      */
     public static function getConnection(
-        #[SensitiveParameter]
         array $params,
         ?Configuration $config = null,
         ?EventManager $eventManager = null
@@ -247,7 +245,6 @@ final class DriverManager
      * @throws Exception
      */
     private static function parseDatabaseUrl(
-        #[SensitiveParameter]
         array $params
     ): array {
         if (! isset($params['url'])) {

--- a/nucleus/libs/vendor/doctrine/dbal/src/Exception.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Exception.php
@@ -4,7 +4,6 @@ namespace Doctrine\DBAL;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
-use SensitiveParameter;
 
 use function get_class;
 use function gettype;
@@ -62,7 +61,6 @@ class Exception extends \Exception
 
     /** @param string|null $url The URL that was provided in the connection parameters (if any). */
     public static function driverRequired(
-        #[SensitiveParameter]
         ?string $url = null
     ): self {
         if ($url !== null) {

--- a/nucleus/libs/vendor/doctrine/dbal/src/Logging/Driver.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Logging/Driver.php
@@ -7,7 +7,6 @@ namespace Doctrine\DBAL\Logging;
 use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
 use Psr\Log\LoggerInterface;
-use SensitiveParameter;
 
 final class Driver extends AbstractDriverMiddleware
 {
@@ -25,7 +24,6 @@ final class Driver extends AbstractDriverMiddleware
      * {@inheritDoc}
      */
     public function connect(
-        #[SensitiveParameter]
         array $params
     ) {
         $this->logger->info('Connecting with parameters {params}', ['params' => $this->maskPassword($params)]);
@@ -42,7 +40,6 @@ final class Driver extends AbstractDriverMiddleware
      * @return array<string,mixed>
      */
     private function maskPassword(
-        #[SensitiveParameter]
         array $params
     ): array {
         if (isset($params['password'])) {

--- a/nucleus/libs/vendor/doctrine/dbal/src/Portability/Driver.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Portability/Driver.php
@@ -7,7 +7,6 @@ use Doctrine\DBAL\Driver as DriverInterface;
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
 use LogicException;
 use PDO;
-use SensitiveParameter;
 
 use function method_exists;
 
@@ -36,7 +35,6 @@ final class Driver extends AbstractDriverMiddleware
      * {@inheritDoc}
      */
     public function connect(
-        #[SensitiveParameter]
         array $params
     ) {
         $connection = parent::connect($params);

--- a/nucleus/libs/vendor/doctrine/dbal/src/Query/Expression/CompositeExpression.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Query/Expression/CompositeExpression.php
@@ -4,7 +4,6 @@ namespace Doctrine\DBAL\Query\Expression;
 
 use Countable;
 use Doctrine\Deprecations\Deprecation;
-use ReturnTypeWillChange;
 
 use function array_merge;
 use function count;
@@ -151,7 +150,6 @@ class CompositeExpression implements Countable
      * @return int
      * @phpstan-return int<0, max>
      */
-    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->parts);

--- a/nucleus/libs/vendor/doctrine/dbal/src/Tools/DsnParser.php
+++ b/nucleus/libs/vendor/doctrine/dbal/src/Tools/DsnParser.php
@@ -5,7 +5,6 @@ namespace Doctrine\DBAL\Tools;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception\MalformedDsnException;
-use SensitiveParameter;
 
 use function array_merge;
 use function assert;
@@ -37,7 +36,6 @@ final class DsnParser
      * @throws MalformedDsnException
      */
     public function parse(
-        #[SensitiveParameter]
         string $dsn
     ): array {
         // (pdo-)?sqlite3?:///... => (pdo-)?sqlite3?://localhost/... or else the URL will be invalid

--- a/nucleus/libs/vendor/doctrine/deprecations/src/PHPUnit/VerifyDeprecations.php
+++ b/nucleus/libs/vendor/doctrine/deprecations/src/PHPUnit/VerifyDeprecations.php
@@ -5,9 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Deprecations\PHPUnit;
 
 use Doctrine\Deprecations\Deprecation;
-use PHPUnit\Framework\Attributes\After;
-use PHPUnit\Framework\Attributes\Before;
-
 use function sprintf;
 
 trait VerifyDeprecations
@@ -29,14 +26,12 @@ trait VerifyDeprecations
     }
 
     /** @before */
-    #[Before]
     public function enableDeprecationTracking(): void
     {
         Deprecation::enableTrackingDeprecations();
     }
 
     /** @after */
-    #[After]
     public function verifyDeprecationsAreTriggered(): void
     {
         foreach ($this->doctrineDeprecationsExpectations as $identifier => $expectation) {


### PR DESCRIPTION
## Summary
- remove PHP 8-only attributes from Doctrine DBAL sources to allow PHP 7.4 parsing
- drop unused attribute imports left after removal

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ac3fd52bc832d8028e89fc79b110b)