### PR TITLE
Add remember login option replacing shared computer setting

### DIFF
--- a/nucleus/language/english-utf8.php
+++ b/nucleus/language/english-utf8.php
@@ -488,8 +488,8 @@ try_define('_ADMIN_SYSTEMOVERVIEW_NOT_ADMIN',			"You haven't enough rights to se
 try_define('_ENCAPSULATE_ENCAPSULATE_NOENTRY',			'No entries');
 
 // globalfunctions.php
-try_define('_GFUNCTIONS_LOGINPCSHARED_YES',				'on shared PC');
-try_define('_GFUNCTIONS_LOGINPCSHARED_NO',				'on not shared PC');
+try_define('_GFUNCTIONS_LOGINPCSHARED_YES',				'login persistence: on');
+try_define('_GFUNCTIONS_LOGINPCSHARED_NO',				'login persistence: off');
 try_define('_GFUNCTIONS_LOGINSUCCESSFUL_TXT',			'Login successful for %s (%s)');
 try_define('_GFUNCTIONS_LOGINFAILED_TXT',				'Login failed for %s');
 try_define('_GFUNCTIONS_LOGOUT_TXT',					'%s is logouted');
@@ -1027,7 +1027,7 @@ try_define('_COMMENTFORM_REMEMBER',		'Remember Me');
 try_define('_LOGINFORM_NAME',			'Username:');
 try_define('_LOGINFORM_PWD',			'Password:');
 try_define('_LOGINFORM_YOUARE',			'Logged in as');
-try_define('_LOGINFORM_SHARED',			'Shared Computer');
+try_define('_LOGINFORM_REMEMBER',			'Remember this login');
 
 // member mailform
 try_define('_MEMBERMAIL_SUBMIT',		'Send Message');
@@ -1416,7 +1416,7 @@ try_define('_BAN_ADD_BTN',				'Add Ban');
 
 // LOGIN screen
 try_define('_LOGIN_MESSAGE',			'Message');
-try_define('_LOGIN_SHARED',				_LOGINFORM_SHARED);
+try_define('_LOGIN_REMEMBER',		_LOGINFORM_REMEMBER);
 try_define('_LOGIN_FORGOT',				'Forgot your password?');
 
 // membermanagement

--- a/nucleus/language/french-utf8.php
+++ b/nucleus/language/french-utf8.php
@@ -408,8 +408,8 @@ try_define('_ADMIN_SYSTEMOVERVIEW_NOT_ADMIN',			"Vous n'avez pas les droit néce
 try_define('_ENCAPSULATE_ENCAPSULATE_NOENTRY',			'Aucune entrée');
 
 // globalfunctions.php
-try_define('_GFUNCTIONS_LOGINPCSHARED_YES',				'sur un ordinateur partagé');
-try_define('_GFUNCTIONS_LOGINPCSHARED_NO',				'sur un ordinateur non-partagé');
+try_define('_GFUNCTIONS_LOGINPCSHARED_YES',				'persistant activé');
+try_define('_GFUNCTIONS_LOGINPCSHARED_NO',				'persistant désactivé');
 try_define('_GFUNCTIONS_LOGINSUCCESSFUL_TXT',			'Connexion réussie pour %s (%s)');
 try_define('_GFUNCTIONS_LOGINFAILED_TXT',				'Echec de la connexion pour %s');
 try_define('_GFUNCTIONS_LOGOUT_TXT',					'%s est déconnecté');
@@ -945,7 +945,7 @@ try_define('_COMMENTFORM_REMEMBER',		'Retenir votre nom');
 try_define('_LOGINFORM_NAME',		'Nom d\'utilisateur');
 try_define('_LOGINFORM_PWD',		'Mot de passe');
 try_define('_LOGINFORM_YOUARE',		'Connecté en tant que');
-try_define('_LOGINFORM_SHARED',		'Ordinateur partagé');
+try_define('_LOGINFORM_REMEMBER',         'Rester connecté');
 
 // member mailform
 try_define('_MEMBERMAIL_SUBMIT',		'Envoyer un message');
@@ -1311,7 +1311,7 @@ try_define('_BAN_ADD_BTN',			'Exclure');
 try_define('_LOGIN_MESSAGE',		'Message');
 try_define('_LOGIN_NAME',			'Nom');
 try_define('_LOGIN_PASSWORD',		'Mot de passe');
-try_define('_LOGIN_SHARED',			_LOGINFORM_SHARED);
+try_define('_LOGIN_REMEMBER',      _LOGINFORM_REMEMBER);
 try_define('_LOGIN_FORGOT',			'Mot de passe oublié?');
 
 // membermanagement

--- a/nucleus/language/german-utf8.php
+++ b/nucleus/language/german-utf8.php
@@ -606,7 +606,7 @@ define('_COMMENTFORM_MAIL',			'eMail/HTTP');
 define('_LOGINFORM_NAME',			'Benutzer');
 define('_LOGINFORM_PWD',			'Passwort');
 define('_LOGINFORM_YOUARE',			'Angemeldet als');
-define('_LOGINFORM_SHARED',			'Shared Computer');
+define('_LOGINFORM_REMEMBER',                    'Angemeldet bleiben');
 
 // member mailform
 define('_MEMBERMAIL_SUBMIT',		'Nachricht absenden');
@@ -969,7 +969,7 @@ define('_BAN_ADD_BTN',				'Zugriffssperre hinzuf&uuml;gen');
 
 // LOGIN screen
 define('_LOGIN_MESSAGE',			'Nachricht');
-define('_LOGIN_SHARED',				_LOGINFORM_SHARED);
+define('_LOGIN_REMEMBER',   _LOGINFORM_REMEMBER);
 define('_LOGIN_FORGOT',				'Passwort vergessen?');
 define('_LOGIN_NAME',				'Name');
 define('_LOGIN_PASSWORD',			'Passwort');

--- a/nucleus/language/japanese-utf8.php
+++ b/nucleus/language/japanese-utf8.php
@@ -519,8 +519,8 @@ try_define('_ADMIN_SYSTEMOVERVIEW_NOT_ADMIN',			'この画面を閲覧する権�
 try_define('_ENCAPSULATE_ENCAPSULATE_NOENTRY',			'エントリーがありません');
 
 // globalfunctions.php
-try_define('_GFUNCTIONS_LOGINPCSHARED_YES',				'共有PCからのログイン');
-try_define('_GFUNCTIONS_LOGINPCSHARED_NO',				'共有ではないPCからのログイン');
+try_define('_GFUNCTIONS_LOGINPCSHARED_YES',				'ログイン状態の保存: 有効');
+try_define('_GFUNCTIONS_LOGINPCSHARED_NO',				'ログイン状態の保存: 無効');
 try_define('_GFUNCTIONS_LOGINSUCCESSFUL_TXT',			'%s がログインしました (%s)');
 try_define('_GFUNCTIONS_LOGINFAILED_TXT',				'%s がログインに失敗しました');
 try_define('_GFUNCTIONS_LOGOUT_TXT',					'%s がログアウトしました');
@@ -1075,7 +1075,7 @@ try_define('_COMMENTFORM_REMEMBER',				'情報を記憶しておく');
 try_define('_LOGINFORM_NAME',					'ログインID:');
 try_define('_LOGINFORM_PWD',					'パスワード:');
 try_define('_LOGINFORM_YOUARE',					'ログイン中:');
-try_define('_LOGINFORM_SHARED',					'このPCを他の人と共用する');
+try_define('_LOGINFORM_REMEMBER',				'ログイン状態を保存する');
 
 // member mailform
 try_define('_MEMBERMAIL_SUBMIT',				'メッセージ送信');
@@ -1464,7 +1464,7 @@ try_define('_BAN_ADD_BTN',						'制限するIPアドレスの追加');
 
 // LOGIN screen
 try_define('_LOGIN_MESSAGE',					'メッセージ');
-try_define('_LOGIN_SHARED',						_LOGINFORM_SHARED);
+try_define('_LOGIN_REMEMBER',              _LOGINFORM_REMEMBER);
 try_define('_LOGIN_FORGOT',						'パスワードを忘れた');
 
 // membermanagement

--- a/nucleus/libs/MEMBER.php
+++ b/nucleus/libs/MEMBER.php
@@ -553,17 +553,16 @@ class MEMBER
     /**
      * Sets the cookies for the member
      *
-     * @param shared
-     *        set this to 1 when using a shared computer. Cookies will expire
-     *        at the end of the session in this case.
+     * @param remember
+     *        set this to 1 when you want to keep the login status. Cookies will
+     *        expire at the end of the session otherwise.
      */
-    public function setCookies($shared = 0)
+    public function setCookies($remember = 0)
     {
         global $CONF;
 
-        if ($CONF['SessionCookie'] || $shared) {
-            $lifetime = 0;
-        } else {
+        $lifetime = 0;
+        if ( ! $CONF['SessionCookie'] && $remember) {
             $lifetime = (time() + 2592000);
         }
 
@@ -584,17 +583,14 @@ class MEMBER
             (bool) $CONF['CookieSecure']
         );
 
-        // make sure cookies on shared pcs don't get renewed
-        if ($shared) {
-            setcookie(
-                (string) $CONF['CookiePrefix'] . 'sharedpc',
-                '1',
-                $lifetime,
-                (string) $CONF['CookiePath'],
-                (string) $CONF['CookieDomain'],
-                (bool) $CONF['CookieSecure']
-            );
-        }
+        setcookie(
+            (string) $CONF['CookiePrefix'] . 'rememberlogin',
+            $remember ? '1' : '',
+            $remember ? $lifetime : (time() - 2592000),
+            (string) $CONF['CookiePath'],
+            (string) $CONF['CookieDomain'],
+            (bool) $CONF['CookieSecure']
+        );
     }
 
     public function sendActivationLink($type, $extra = '')

--- a/nucleus/libs/globalfunctions.php
+++ b/nucleus/libs/globalfunctions.php
@@ -261,7 +261,7 @@ if ('login' === requestVar('action')) {
     // avoid md5 collision by using a long key
     if ($member->login(postVar('login'), substr(postVar('password'), 0, 40))) {
         $member->newCookieKey();
-        $member->setCookies(intPostVar('shared'));
+        $member->setCookies(intPostVar('remember'));
         if ('none' !== confVar('secureCookieKey')) {
             // secure cookie key
             $member->setCookieKey(
@@ -281,9 +281,9 @@ if ('login' === requestVar('action')) {
         ];
         $manager->notify('LoginSuccess', $param);
         $log_message = sprintf(
-            "Login successful for %s (sharedpc=%s)",
+            "Login successful for %s (rememberlogin=%s)",
             postVar('login'),
-            intPostVar('shared')
+            intPostVar('remember')
         );
 
         $remote_ip   = serverVar('REMOTE_ADDR', '');
@@ -349,6 +349,14 @@ if ('login' === requestVar('action')) {
         confVar('CookieDomain'),
         (bool) confVar('CookieSecure')
     );
+    setcookie(
+        confVar('CookiePrefix') . 'rememberlogin',
+        '',
+        time() - 2592000,
+        confVar('CookiePath'),
+        confVar('CookieDomain'),
+        (bool) confVar('CookieSecure')
+    );
     $param = ['username' => cookieVar(confVar('CookiePrefix') . 'user')];
     $manager->notify('Logout', $param);
 } elseif (cookieVar(confVar('CookiePrefix') . 'user')) {
@@ -365,11 +373,11 @@ if ('login' === requestVar('action')) {
     );
     unset($ck);
 
-    // renew cookies when not on a shared computer
-    if ($res && (1 != cookieVar(confVar('CookiePrefix') . 'sharedpc'))
+    // renew cookies when login persistence is enabled
+    if ($res && (1 == cookieVar(confVar('CookiePrefix') . 'rememberlogin'))
         && ( ! headers_sent())) {
         $member->setCookieKey(cookieVar(confVar('CookiePrefix') . 'loginkey'));
-        $member->setCookies();
+        $member->setCookies(1);
     }
 }
 

--- a/nucleus/libs/template/forms/loginform-notloggedin.template
+++ b/nucleus/libs/template/forms/loginform-notloggedin.template
@@ -9,8 +9,8 @@
 		<label for="nucleus_lf_pwd"><%text(_LOGINFORM_PWD)%></label>
 		<input id="nucleus_lf_pwd" name="password" size="10" type="password" value="" class="formfield" />
 
-		<input type="checkbox" value="1" name="shared" id="nucleus_lf_shared" />
-		<label for="nucleus_lf_shared"><%text(_LOGINFORM_SHARED)%></label>
+                <input type="checkbox" value="1" name="remember" id="nucleus_lf_remember" />
+                <label for="nucleus_lf_remember"><%text(_LOGINFORM_REMEMBER)%></label>
 
 		<input type="submit" alt="<%text(_LOGIN)%>" value="<%text(_LOGIN)%>" class="formbutton" />
 	</div>

--- a/nucleus/views/admin/action_showlogin.blade.php
+++ b/nucleus/views/admin/action_showlogin.blade.php
@@ -13,7 +13,7 @@
         <input type="submit" value="{{ _LOGIN }}" tabindex="30" />
         <br />
         <small>
-            <input type="checkbox" value="1" name="shared" tabindex="40" id="shared" /><label for="shared">{{ _LOGIN_SHARED }}</label>
+            <input type="checkbox" value="1" name="remember" tabindex="40" id="remember" /><label for="remember">{{ _LOGIN_REMEMBER }}</label>
             <br /><a href="{{ ADMIN::getAdminRootURI() }}index.php?action=lost_pwd">{{ _LOGIN_FORGOT }}</a>
         </small>
         @if($passRequestVars) @php \passRequestVars(); @endphp @endif

--- a/nucleus/views/admin/login.blade.php
+++ b/nucleus/views/admin/login.blade.php
@@ -32,8 +32,8 @@
 
                 <div class="login-form__options">
                     <label class="login-checkbox">
-                        <input type="checkbox" value="1" name="shared" tabindex="40" />
-                        <span>{{ _LOGIN_SHARED }}</span>
+                        <input type="checkbox" value="1" name="remember" tabindex="40" />
+                        <span>{{ _LOGIN_REMEMBER }}</span>
                     </label>
                     <button type="button" class="login-form__link" id="forgot-password-trigger">{{ _LOGIN_FORGOT }}</button>
                 </div>


### PR DESCRIPTION
## Summary
- replace the shared-computer checkbox with a remember login option across login forms
- adjust authentication cookie handling to respect opt-in login persistence and drop the old shared flag
- refresh language strings for the new remember login wording

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943e0982394832d97944028b22a9052)